### PR TITLE
Add extension method to add alfresco repository

### DIFF
--- a/src/integration-test/resources/examples/simple-alfresco-project/build.gradle
+++ b/src/integration-test/resources/examples/simple-alfresco-project/build.gradle
@@ -11,10 +11,9 @@ ext.alfrescoVersion = "5.2.g"
 repositories {
     mavenCentral()
     jcenter()
-    maven {
-        url "https://artifacts.alfresco.com/nexus/content/groups/public/"
-    }
+    alfrescoPublic()
 }
+
 
 dependencies {
     alfrescoProvided "org.alfresco:alfresco-repository:${alfrescoVersion}"

--- a/src/main/java/eu/xenit/gradle/alfrescosdk/AlfrescoPlugin.java
+++ b/src/main/java/eu/xenit/gradle/alfrescosdk/AlfrescoPlugin.java
@@ -1,14 +1,23 @@
 package eu.xenit.gradle.alfrescosdk;
 
+import groovy.lang.Closure;
+import groovy.lang.GroovyObject;
+import org.codehaus.groovy.runtime.MethodClosure;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.dsl.RepositoryHandler;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.plugins.ExtraPropertiesExtension;
 import org.gradle.api.plugins.JavaPlugin;
 
 public class AlfrescoPlugin implements Plugin<Project> {
 
     public static final String ALFRESCO_PROVIDED = "alfrescoProvided";
     public static final String PLUGIN_ID = "eu.xenit.alfresco";
+    public static final String ALFRESCO_REPOSITORY_PUBLIC = "https://artifacts.alfresco.com/nexus/content/groups/public/";
+    private static final Logger LOGGER = Logging.getLogger(AlfrescoPlugin.class);
 
     @Override
     public void apply(Project project) {
@@ -18,5 +27,28 @@ public class AlfrescoPlugin implements Plugin<Project> {
         compileOnly.extendsFrom(alfrescoProvided);
         Configuration testRuntime = project.getConfigurations().getByName("testImplementation");
         testRuntime.extendsFrom(alfrescoProvided);
+
+        RepositoryHandler repositories = project.getRepositories();
+        // RepositoryHandler does not implement GroovyObject directly, but
+        // its implementation or generated delegate will have to implement
+        // this class to be usable from groovy code.
+        if(repositories instanceof GroovyObject) {
+            GroovyObject groovyRepositories = (GroovyObject)repositories;
+            // By convention, all groovy objects have an "ext" property, which can be used to add extra fields
+            // and functions to an object. All methods an properties that are added to this ext property can be used
+            // from Groovy code as if they exist directly on the object.
+            ExtraPropertiesExtension ext = (ExtraPropertiesExtension) groovyRepositories.getProperty("ext");
+            Closure alfrescoClosure = new Closure(this) {
+                public void doCall() {
+                    repositories.maven(repo -> {
+                        repo.setUrl(ALFRESCO_REPOSITORY_PUBLIC);
+                        repo.setName("Alfresco Public");
+                    });
+                }
+            };
+            ext.set("alfrescoPublic", alfrescoClosure);
+        } else {
+            LOGGER.error("Could not register artifacts.alfrescoPublic() extension.");
+        }
     }
 }


### PR DESCRIPTION
This makes it possible to easily add the Alfresco public maven repository to `repositories{}` with a function call.

Adding the public alfresco maven repository will look similar to adding jcenter and mavenCentral repositories:

 ```gradle
repositories {
   alfrescoPublic()
}
```