### PR TITLE
Add support + test for dynamic extensions amps

### DIFF
--- a/src/integration-test/java/eu/xenit/gradle/alfrescosdk/Examples.java
+++ b/src/integration-test/java/eu/xenit/gradle/alfrescosdk/Examples.java
@@ -14,4 +14,8 @@ public class Examples extends AbstractIntegrationTest {
         testProjectFolder(EXAMPLES.resolve("simple-alfresco-project"));
     }
 
+    @Test
+    public void testSimpleDeProject() throws IOException {
+        testProjectFolder(EXAMPLES.resolve("simple-de-project"));
+    }
 }

--- a/src/integration-test/resources/examples/simple-de-project/build.gradle
+++ b/src/integration-test/resources/examples/simple-de-project/build.gradle
@@ -1,0 +1,32 @@
+buildscript {
+    dependencies {
+        classpath "eu.xenit.de:gradle-plugin:1.7.6"
+    }
+}
+
+plugins {
+    id 'eu.xenit.alfresco'
+    id 'eu.xenit.amp'
+}
+
+apply plugin: 'alfresco-dynamic-extension'
+
+description = "HelloWorld Webscript, very useful"
+version = "0.0.1"
+
+ext.alfrescoVersion = "5.2.g"
+
+repositories {
+    mavenCentral()
+    jcenter()
+    alfrescoPublic()
+}
+
+amp {
+    de {
+        from project.jar
+    }
+}
+dependencies {
+    alfrescoProvided "org.alfresco:alfresco-repository:${alfrescoVersion}"
+}

--- a/src/integration-test/resources/examples/simple-de-project/build.gradle
+++ b/src/integration-test/resources/examples/simple-de-project/build.gradle
@@ -11,6 +11,10 @@ plugins {
 
 apply plugin: 'alfresco-dynamic-extension'
 
+ampConfig {
+    dynamicExtensionAmp = true
+}
+
 description = "HelloWorld Webscript, very useful"
 version = "0.0.1"
 
@@ -22,11 +26,6 @@ repositories {
     alfrescoPublic()
 }
 
-amp {
-    de {
-        from project.jar
-    }
-}
 dependencies {
     alfrescoProvided "org.alfresco:alfresco-repository:${alfrescoVersion}"
 }

--- a/src/integration-test/resources/examples/simple-de-project/src/main/amp/module.properties
+++ b/src/integration-test/resources/examples/simple-de-project/src/main/amp/module.properties
@@ -1,0 +1,4 @@
+module.id=$project.name
+module.description=$project.description
+module.version=$project.version
+module.title=$project.name

--- a/src/integration-test/resources/examples/simple-de-project/src/main/java/eu/xenit/alfresco/gradle/sample/HelloWorldWebScript.java
+++ b/src/integration-test/resources/examples/simple-de-project/src/main/java/eu/xenit/alfresco/gradle/sample/HelloWorldWebScript.java
@@ -1,0 +1,17 @@
+package eu.xenit.alfresco.gradle.sample;
+
+import java.io.IOException;
+import org.springframework.extensions.webscripts.WebScriptResponse;
+import org.springframework.stereotype.Component;
+import com.github.dynamicextensionsalfresco.webscripts.annotations.Uri;
+import com.github.dynamicextensionsalfresco.webscripts.annotations.WebScript;
+import com.github.dynamicextensionsalfresco.webscripts.annotations.HttpMethod;
+
+@Component
+@WebScript(baseUri = "/eu/xenit")
+public class HelloWorldWebScript {
+    @Uri(value = "/helloworld", method = HttpMethod.GET)
+    public void execute(WebScriptResponse res) throws IOException {
+        res.getWriter().write("<h1>Hello World</h1>");
+    }
+}

--- a/src/main/java/eu/xenit/gradle/alfrescosdk/AmpPlugin.java
+++ b/src/main/java/eu/xenit/gradle/alfrescosdk/AmpPlugin.java
@@ -4,6 +4,7 @@ import eu.xenit.gradle.alfrescosdk.config.AmpConfig;
 import eu.xenit.gradle.alfrescosdk.tasks.Amp;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.FileCollection;
 
 public class AmpPlugin implements Plugin<Project> {
@@ -29,8 +30,17 @@ public class AmpPlugin implements Plugin<Project> {
         project.getPluginManager().withPlugin(AlfrescoPlugin.PLUGIN_ID, appliedPlugin -> {
             FileCollection runtime = project.getConfigurations().getAt("runtime");
             FileCollection jarArtifact = project.getTasks().getAt("jar").getOutputs().getFiles();
-            FileCollection libs = runtime.plus(jarArtifact);
-            amp.setLibs(libs);
+            FileCollection jars = runtime.plus(jarArtifact);
+            amp.setLibs(jars);
+            project.afterEvaluate(p -> {
+                if (ampConfig.getDynamicExtensionAmp()) {
+                    amp.de((CopySpec c) -> c.from(jars));
+                    // Reset libs only when they have not been changed directly in the task
+                    if(amp.getLibs() == jars) {
+                        amp.setLibs(null);
+                    }
+                }
+            });
         });
     }
 }

--- a/src/main/java/eu/xenit/gradle/alfrescosdk/config/AmpConfig.java
+++ b/src/main/java/eu/xenit/gradle/alfrescosdk/config/AmpConfig.java
@@ -2,7 +2,6 @@ package eu.xenit.gradle.alfrescosdk.config;
 
 import java.io.File;
 import java.util.function.Supplier;
-import org.gradle.api.PathValidation;
 import org.gradle.api.Project;
 
 public class AmpConfig {
@@ -13,7 +12,8 @@ public class AmpConfig {
     private Supplier<File> moduleProperties;
     private Supplier<File> configDir;
     private Supplier<File> webDir;
-    private Supplier<File> fileMappingProperties ;
+    private Supplier<File> fileMappingProperties;
+    private boolean dynamicExtensionAmp = false;
 
     private final Project project;
     public AmpConfig(Project project){
@@ -35,7 +35,6 @@ public class AmpConfig {
                 return null;
             }
         };
-
     }
 
     public File getModuleProperties() {
@@ -104,5 +103,13 @@ public class AmpConfig {
 
     public Supplier<File> getFileMappingPropertiesSupplier() {
         return this.fileMappingProperties;
+    }
+
+    public boolean getDynamicExtensionAmp() {
+        return this.dynamicExtensionAmp;
+    }
+
+    public void setDynamicExtensionAmp(boolean dynamicExtensionAmp) {
+        this.dynamicExtensionAmp = dynamicExtensionAmp;
     }
 }

--- a/src/main/java/eu/xenit/gradle/alfrescosdk/tasks/Amp.java
+++ b/src/main/java/eu/xenit/gradle/alfrescosdk/tasks/Amp.java
@@ -93,10 +93,7 @@ public class Amp extends Zip {
 
     @Internal
     private CopySpec getDe() {
-        if (deCopySpec == null) {
-            deCopySpec = ampCopySpec.addChild().into("config/dynamic-extensions/bundles");
-        }
-        return deCopySpec;
+        return ampCopySpec.addChild().into("config/dynamic-extensions/bundles");
     }
 
     @InputFiles

--- a/src/main/java/eu/xenit/gradle/alfrescosdk/tasks/Amp.java
+++ b/src/main/java/eu/xenit/gradle/alfrescosdk/tasks/Amp.java
@@ -34,6 +34,8 @@ public class Amp extends Zip {
 
     private DefaultCopySpec ampCopySpec;
 
+    private CopySpec deCopySpec;
+
     public Amp() {
         setExtension(AMP_EXTENSION);
         setDestinationDir(getProject().getBuildDir().toPath().resolve("dist").toFile());
@@ -90,8 +92,11 @@ public class Amp extends Zip {
     }
 
     @Internal
-    public CopySpec getDeCopySpec() {
-        return ampCopySpec.addChild().into("config/dynamic-extensions/bundles");
+    private CopySpec getDe() {
+        if (deCopySpec == null) {
+            deCopySpec = ampCopySpec.addChild().into("config/dynamic-extensions/bundles");
+        }
+        return deCopySpec;
     }
 
     @InputFiles
@@ -114,14 +119,12 @@ public class Amp extends Zip {
         this.licenses = licenses;
     }
 
-    public CopySpec de(Closure configureClosure) {
-        return ConfigureUtil.configure(configureClosure, getDeCopySpec());
+    public void de(Closure configureClosure) {
+        ConfigureUtil.configure(configureClosure, getDe());
     }
 
-    public CopySpec de(Action<? super CopySpec> configureAction) {
-        CopySpec amp = getDeCopySpec();
-        configureAction.execute(amp);
-        return amp;
+    public void de(Action<? super CopySpec> configureAction) {
+        configureAction.execute(getDe());
     }
 
     @InputDirectory

--- a/src/main/java/eu/xenit/gradle/alfrescosdk/tasks/Amp.java
+++ b/src/main/java/eu/xenit/gradle/alfrescosdk/tasks/Amp.java
@@ -34,8 +34,6 @@ public class Amp extends Zip {
 
     private DefaultCopySpec ampCopySpec;
 
-    private CopySpec deCopySpec;
-
     public Amp() {
         setExtension(AMP_EXTENSION);
         setDestinationDir(getProject().getBuildDir().toPath().resolve("dist").toFile());

--- a/src/test/java/eu/xenit/gradle/alfrescosdk/AmpPluginTest.java
+++ b/src/test/java/eu/xenit/gradle/alfrescosdk/AmpPluginTest.java
@@ -34,4 +34,26 @@ public class AmpPluginTest {
         assertTrue(ampTask.getConfig().isDirectory());
     }
 
+    @Test
+    public void testDeProjectWithEmptyLib(){
+        DefaultProject project = getDefaultProject();
+        project.getPluginManager().apply(AlfrescoPlugin.class);
+        project.getExtensions().configure("ampConfig", (AmpConfig ampConfig) -> ampConfig.setDynamicExtensionAmp(true));
+
+        Amp ampTask = (Amp) project.getTasks().getByName("amp");
+        project.evaluate(); // Evaluate the project so that the afterEvaluate can run, which should clear the libs
+        assertNull(ampTask.getLibs());
+    }
+
+    @Test
+    public void testDeProjectWithConfiguredLib(){
+        DefaultProject project = getDefaultProject();
+        project.getPluginManager().apply(AlfrescoPlugin.class);
+        project.getExtensions().configure("ampConfig", (AmpConfig ampConfig) -> ampConfig.setDynamicExtensionAmp(true));
+
+        Amp ampTask = (Amp) project.getTasks().getByName("amp");
+        ampTask.setLibs(project.files("this/doesnt/exist"));
+        project.evaluate(); // Evaluate the project so that the afterEvaluate can run, which should leave the libs alone
+        assertNotNull(ampTask.getLibs());
+    }
 }


### PR DESCRIPTION
Basic support for making a dynamic extensions amp by leveraging the existing dynamic extensions gradle plugin and just embedding the resulting jar in the amp. The syntax for this in the build.gradle is:
```
amp {
    de {
        from project.jar
    }
}
```