### PR TITLE
Throw an exception when applying the plugins on gradle < 4.10

### DIFF
--- a/src/main/java/eu/xenit/gradle/alfrescosdk/AlfrescoPlugin.java
+++ b/src/main/java/eu/xenit/gradle/alfrescosdk/AlfrescoPlugin.java
@@ -1,5 +1,6 @@
 package eu.xenit.gradle.alfrescosdk;
 
+import eu.xenit.gradle.alfrescosdk.internal.GradleVersionCheck;
 import groovy.lang.Closure;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Plugin;
@@ -24,6 +25,8 @@ public class AlfrescoPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
+        GradleVersionCheck.assertSupportedVersion(PLUGIN_ID);
+
         this.project = project;
         project.getPluginManager().apply(JavaPlugin.class);
 

--- a/src/main/java/eu/xenit/gradle/alfrescosdk/AmpBasePlugin.java
+++ b/src/main/java/eu/xenit/gradle/alfrescosdk/AmpBasePlugin.java
@@ -1,6 +1,7 @@
 package eu.xenit.gradle.alfrescosdk;
 
 import eu.xenit.gradle.alfrescosdk.internal.ConfigurationDispatcher;
+import eu.xenit.gradle.alfrescosdk.internal.GradleVersionCheck;
 import eu.xenit.gradle.alfrescosdk.internal.tasks.DefaultAmpSourceSet;
 import eu.xenit.gradle.alfrescosdk.tasks.Amp;
 import eu.xenit.gradle.alfrescosdk.tasks.AmpSourceSet;
@@ -33,6 +34,7 @@ import org.slf4j.Logger;
 public class AmpBasePlugin implements Plugin<Project> {
 
     public static final Logger LOGGER = Logging.getLogger(AmpBasePlugin.class);
+    public static final String PLUGIN_ID = "eu.xenit.amp-base";
 
     private final SourceDirectorySetFactory sourceDirectorySetFactory;
     private final ConfigurationDispatcher<DefaultAmpSourceSet> sourceSetConfigurationDispatcher;
@@ -46,6 +48,7 @@ public class AmpBasePlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project target) {
+        GradleVersionCheck.assertSupportedVersion(PLUGIN_ID);
         project = target;
         project.getPluginManager().apply(JavaBasePlugin.class);
         configureSourceSetDefaults();

--- a/src/main/java/eu/xenit/gradle/alfrescosdk/AmpPlugin.java
+++ b/src/main/java/eu/xenit/gradle/alfrescosdk/AmpPlugin.java
@@ -1,5 +1,6 @@
 package eu.xenit.gradle.alfrescosdk;
 
+import eu.xenit.gradle.alfrescosdk.internal.GradleVersionCheck;
 import eu.xenit.gradle.alfrescosdk.tasks.Amp;
 import eu.xenit.gradle.alfrescosdk.tasks.AmpSourceSet;
 import org.gradle.api.Plugin;
@@ -14,6 +15,8 @@ import org.gradle.plugins.ide.idea.IdeaPlugin;
 
 public class AmpPlugin implements Plugin<Project> {
 
+    public static final String PLUGIN_ID = "eu.xenit.amp";
+
     @Deprecated
     public static final String AMP_CONFIGURATION = "amp";
     @Deprecated
@@ -23,6 +26,8 @@ public class AmpPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
+        GradleVersionCheck.assertSupportedVersion(PLUGIN_ID);
+
         project.getPluginManager().apply(AmpBasePlugin.class);
         project.getPluginManager().apply(AmpLegacyPlugin.class);
 

--- a/src/main/java/eu/xenit/gradle/alfrescosdk/internal/GradleVersionCheck.java
+++ b/src/main/java/eu/xenit/gradle/alfrescosdk/internal/GradleVersionCheck.java
@@ -1,0 +1,20 @@
+package eu.xenit.gradle.alfrescosdk.internal;
+
+import org.gradle.api.GradleException;
+import org.gradle.util.GradleVersion;
+
+public final class GradleVersionCheck {
+    private GradleVersionCheck() {
+
+    }
+    private static final GradleVersion MINIMUM_VERSION = GradleVersion.version("4.10");
+    public static void assertSupportedVersion(String pluginId) {
+        GradleVersion currentVersion = GradleVersion.current();
+
+        if(MINIMUM_VERSION.compareTo(currentVersion) > 0) {
+            throw new GradleException("The "+pluginId+" plugin requires at least "+MINIMUM_VERSION+". (You are running "+currentVersion+")");
+        }
+
+    }
+
+}


### PR DESCRIPTION
Because we use the new configuration avoidance API, Gradle versions
older than 4.10 are not supported. Attempting to use an older version
resulted in a NoSuchMethodError, which does not point to the cause of
the error at all.

Fixes #13