### PR TITLE
Handle non-string objects being added to properties files

### DIFF
--- a/src/integrationTest/resources/examples/multi-source-alfresco-project/build.gradle
+++ b/src/integrationTest/resources/examples/multi-source-alfresco-project/build.gradle
@@ -3,22 +3,27 @@ plugins {
     id 'eu.xenit.amp'
 }
 
+version = "0.0.1"
+
 sourceSets {
     main {
-
+        amp {
+            module([
+                "module.id": "${project.name}-repo",
+                "module.version": project.version
+            ])
+        }
     }
     share {
         amp {
             module {
-                it.setProperty("module.id", project.name + "-share")
+                it.setProperty("module.id", "${project.name}-share")
                 it.setProperty("module.version", project.version)
             }
         }
     }
 }
 
-description = "HelloWorld Webscript, very useful"
-version = "0.0.1"
 
 repositories {
     mavenCentral()

--- a/src/main/java/eu/xenit/gradle/alfrescosdk/AmpBasePlugin.java
+++ b/src/main/java/eu/xenit/gradle/alfrescosdk/AmpBasePlugin.java
@@ -56,9 +56,9 @@ public class AmpBasePlugin implements Plugin<Project> {
     }
 
     private static Map<String, Object> propertiesToMap(Properties properties) {
-        return properties.stringPropertyNames()
+        return properties.keySet()
                 .stream()
-                .collect(Collectors.toMap(Function.identity(), properties::getProperty));
+                .collect(Collectors.toMap(Object::toString, k -> properties.get(k).toString()));
     }
 
 


### PR DESCRIPTION
This issue is most importantly caused by using string interpolation in
gradle, which creates a GString that is lazily interpolated when it is
used as a string somewhere. Explicitly cast all keys and values of the
properties maps to strings, so they are all included when a properties
file is written.

Fixes #11