### PR TITLE
Fix the incremental task "integrationTest"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 }
 
 task integrationTest(type: Test, group: "verification") {
+    inputs.files fileTree(dir: "$project.projectDir/src/integrationTest", exclude: "**/.gradle")
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
     mustRunAfter(test)


### PR DESCRIPTION
Hello

This commit fixes the incremental task "integrationTest".

Specifically, this tasks runs the integration tests of the project. However, some tests depend on some files and resources found in the `src/integrationTest` directory.

This commit adds the right inputs for the `integrationTest` task so that if there is any change in those files, the incremental task "integrationTest" is triggered correctly.