### PR TITLE
Document usage of `it` metavariable in `module {}` closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ sourceSets {
             module(project.file("path/to/module.properties"))
             // 2. Dynamic configuration with a lazily evaluated closure
             module { 
-                put("module.id", project.name)
-                put("module.version", project.version)
+                it.put("module.id", project.name)
+                it.put("module.version", project.version)
             }
             // 3. Dynamic configuration with an eagerly evaluated map
             module([ 

--- a/build.gradle
+++ b/build.gradle
@@ -39,12 +39,17 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'commons-io', name: 'commons-io', version: '2.6'
 }
-
+import org.gradle.util.GradleVersion
 task integrationTest(type: Test, group: "verification") {
     inputs.files fileTree(dir: "$project.projectDir/src/integrationTest", exclude: "**/.gradle")
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
     mustRunAfter(test)
+    doFirst {
+        if (gradle.startParameter.offline) {
+            systemProperty "eu.xenit.gradle.alfrescosdk.integration.useGradleVersion", GradleVersion.current().version
+        }
+    }
 }
 
 tasks.withType(Test) {
@@ -68,7 +73,7 @@ gradlePlugin {
             id = "eu.xenit.amp"
             implementationClass = "eu.xenit.gradle.alfrescosdk.AmpPlugin"
         }
-        
+
         alfresco {
             id = "eu.xenit.alfresco"
             implementationClass = "eu.xenit.gradle.alfrescosdk.AlfrescoPlugin"

--- a/src/integrationTest/java/eu/xenit/gradle/alfrescosdk/AbstractIntegrationTest.java
+++ b/src/integrationTest/java/eu/xenit/gradle/alfrescosdk/AbstractIntegrationTest.java
@@ -28,6 +28,12 @@ public abstract class AbstractIntegrationTest {
 
     @Parameters(name = "Gradle v{0}")
     public static Collection<Object[]> testData() {
+        String forceGradleVersion = System.getProperty("eu.xenit.gradle.alfrescosdk.integration.useGradleVersion");
+        if (forceGradleVersion != null) {
+            return Arrays.asList(new Object[][]{
+                    {forceGradleVersion},
+            });
+        }
         return Arrays.asList(new Object[][]{
                 {"6.0.1"},
                 {"5.6.4"},
@@ -50,14 +56,17 @@ public abstract class AbstractIntegrationTest {
 
     private GradleRunner createRunnerInPlace(Path tempExample, String task) {
         File tempExampleFile = tempExample.toFile();
-        System.out.println("Executing test build for example " + tempExampleFile.getName());
-        return GradleRunner.create()
+        GradleRunner runner = GradleRunner.create()
                 .withProjectDir(tempExampleFile)
-                .withGradleVersion(gradleVersion)
                 .withArguments(task, "--stacktrace", "-i")
                 .withPluginClasspath()
                 .withDebug(true)
                 .forwardOutput();
+
+        if (System.getProperty("eu.xenit.gradle.integration.useGradleVersion") == null) {
+            return runner.withGradleVersion(gradleVersion);
+        }
+        return runner;
     }
 
     protected Path getTempCopy(Path projectFolder) throws IOException {


### PR DESCRIPTION
Fixes #32 by documenting use of `it` meta-variable